### PR TITLE
Fix 'if then' statement for platform case

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "http://api.berkshelf.com"
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/recipes/mongodb_org_repo.rb
+++ b/recipes/mongodb_org_repo.rb
@@ -31,7 +31,7 @@ end
 
 case node['platform_family']
 when 'debian'
-  if if major == '3' && minor == '2'
+  if major == '3' && minor == '2'
     gpgkey = 'EA312927'
   else
     gpgkey = '7F0CEB10'


### PR DESCRIPTION
A typo inside of a case statement for debian meant that this cookbook was failing to converge in kitchen when testing on that flavour of OS.
